### PR TITLE
Error handling overhaul. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json

--- a/example/bulkInsert.py
+++ b/example/bulkInsert.py
@@ -41,7 +41,7 @@ def run(batchSize: int):
     # create demo table 
     result=client.query(sql="CREATE TABLE demo_upload(_id ID, keycol INT, val1 STRING, val2 STRING)")
     if not result.ok:
-        print(result.error.description)
+        print(result.error)
     # insert batchSize rows per insert for 1000 times
     n=int(1000000/batchSize)
     l=1

--- a/src/featurebase/__init__.py
+++ b/src/featurebase/__init__.py
@@ -1,1 +1,1 @@
-from .client import client, result, error
+from .client import client, result


### PR DESCRIPTION
Error handling is separated into SQL error vs everything else. SQL errors are gracefully trapped and reported in result object, all other exceptions are re-thrown for the application to handle. 

When there is a SQL error the `result` object is populated with error details as follows:
- `result.ok` will be false
- `result.error` will have the error message returned by the server

The client will re-throw all other exceptions it faces.
 
With these changes there is no need for a separate `error` class and it is deprecated.

A new attribute `raw_response` is added to `result` class to help with troubleshooting.