### PR TITLE
set hostport default inside constructor, not in signature

### DIFF
--- a/src/featurebase/client.py
+++ b/src/featurebase/client.py
@@ -29,7 +29,7 @@ class client:
     # make connection to the sql endpoint
     def __init__(
         self,
-        hostport="localhost:10101",
+        hostport=None,
         database=None,
         apikey=None,
         cafile=None,


### PR DESCRIPTION
We need to distinguish "hostport unspecified" from "hostport has default value", so the default value in the signature for __init__ should be None; the actual default is set down below inside the init function, after a check to make sure we are okay with using a default.